### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/dissect/executable/elf/elf.py
+++ b/dissect/executable/elf/elf.py
@@ -321,7 +321,7 @@ class StringTable(Section):
     def __init__(self, fh: BinaryIO, idx: Optional[int] = None, c_elf: cstruct = c_elf_64):
         super().__init__(fh, idx, c_elf)
 
-        self._get_string = lru_cache(self._get_string)
+        self._get_string = lru_cache(256)(self._get_string)
 
     def __getitem__(self, offset: int) -> str:
         return self._get_string(offset)


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)